### PR TITLE
README: fix url to `zinit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `zsh-defer` defers execution of a zsh command until zsh has nothing else to do and is waiting for
 user input. Its intended purpose is staged zsh startup. It works similarly to *Turbo mode* in
-[zinit](https://github.com/zdharma/zinit).
+[zinit](https://github.com/zdharma-continuum/zinit).
 
 Features:
 


### PR DESCRIPTION
Fix the URL linking `zinit` project in the README.

The original repo of `zinit` was randomly deleted by its original author.
The `zinit` development is continuing [here](https://github.com/zdharma-continuum/zinit). 